### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
   # Start the install of everything
   - pip install --upgrade pip wheel
-  - "pip install --only-binary :all: --pre -f $WXPYTHON_SNAPSHOTS wxPython_Phoenix"
+  - "pip install --only-binary :all: --pre -f $WXPYTHON_SNAPSHOTS wxPython"
   - pip install -r requirements.txt
   - pip install -r dev-requirements.txt
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
   - python: "3.5"
     env:
-      - WXPYTHON_SNAPSHOTS=https://wxpython.org/Phoenix/snapshot-builds/linux/gtk3/ubuntu-16.04/
+      - WXPYTHON_SNAPSHOTS=https://wxpython.org/Phoenix/snapshot-builds/linux/gtk3/ubuntu-14.04/
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@
 skip_tags: true
 
 environment:
-  global:
-    WXPYTHON_SNAPSHOTS: "https://wxpython.org/Phoenix/snapshot-builds"
-
   matrix:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.2"
@@ -32,9 +29,7 @@ install:
   # install dependencies
   - "%PYTHON%\\python.exe -m pip install --upgrade pip wheel"
 
-
-  - "%PYTHON%\\python.exe -m pip install --only-binary :all: --pre -f %WXPYTHON_SNAPSHOTS% wxPython_Phoenix"
-  - "%PYTHON%\\python.exe -m pip install --only-binary :all: numpy lxml"
+  - "%PYTHON%\\python.exe -m pip install --pre wxPython>=4.0.0a1"
 
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip install -r dev-requirements.txt"


### PR DESCRIPTION
This PR updates CI to actually run again, now that various things outside of my control have been changed, such as the package "wxPython_Phoenix" no longer existing (it's finally been merged into wxPython).

+ Appveyor
  + pull wxPython from pypi, as wheels are hosted there now.
  + allow the requirements.txt file to handle installing lxml and numpy (no longer need to specify `only-binary :all:` for them)
+ Travis
  + change package name of wxpython
  + use correct ubuntu version snapshot location for wxPython wheels