### PR TITLE
Fixed DeprecationWarning: invalid escape sequence

### DIFF
--- a/pybank/parseofx.py
+++ b/pybank/parseofx.py
@@ -464,7 +464,7 @@ def convert_datetime(ofx_dt):
 
     """
     # Get the time zone
-    tz_type = re.search("\[(?P<tz>[-+]?\d+\.?\d*)\:\w*\]$", ofx_dt)
+    tz_type = re.search(r"\[(?P<tz>[-+]?\d+\.?\d*)\:\w*\]$", ofx_dt)
     if tz_type is not None:
         tz = float(tz_type.group('tz'))
     else:


### PR DESCRIPTION
This PR attempts to fix the `DeprecationWarning`s that have been popping up when running `pytest`, but sadly it only fixes one of them.

+ Fixed invalid escape sequence by marking a regex string as raw.

The other warning pops up multiple times:
```
tests/test_parseofx.py::TestParseStatus_OKAllTags::test_attributes_exist
  c:\dev_python\pybank\.venv36\lib\site-packages\bs4\builder\_lxml.py:132: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
    self.parser.feed(data)
```

As the stacktrace shows, this appears to be an issue with the `BeautifulSoup4` or `lxml` libraries, but I haven't been able to figure out a workaround or even where the `inspect.getargspec()` function is being called. A grep on the entire code base for `bs4` and `lxml` turns up nothing.